### PR TITLE
ID-33: Load FHIR R4 base definitions to support the ofType function

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [17.x, 11.x]
+        java: [17.x]
 
     name: Java ${{ matrix.java }} Build
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11 AS build
+FROM eclipse-temurin:11 AS build
 
 # RUN curl -ksSL https://gitlab.mitre.org/mitre-scripts/mitre-pki/raw/master/os_scripts/install_certs.sh | MODE=ubuntu sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11 AS build
+FROM eclipse-temurin:17 AS build
 
 # RUN curl -ksSL https://gitlab.mitre.org/mitre-scripts/mitre-pki/raw/master/os_scripts/install_certs.sh | MODE=ubuntu sh
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ the functionality provided by this service is [implemented within the HL7® FHIR
 Core library](https://github.com/hapifhir/org.hl7.fhir.core), which is
 developed and maintained independently of this project.
 
+## Definitions
+
+The base FHIR R4 definitions are loaded during setup. No other IGs or FHIR
+versions are currently available.
 
 ## REST API
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
     // Web Server
     implementation("com.sparkjava", "spark-core", "2.9.4")
 
+    // Package Loading
+    implementation("org.apache.commons", "commons-compress", "1.28.0")
+
     // Testing stuff
     testImplementation("org.junit.jupiter", "junit-jupiter", "5.9.3")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,8 +38,8 @@ dependencies {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_11
-    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_17
 }
 
 application {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.0.1
+version=0.1.0
 
 # version of org.hl7.fhir.*
-fhirCoreVersion=6.3.6
+fhirCoreVersion=6.7.10

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -7,11 +7,12 @@ import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.context.SimpleWorkerContext;
 import org.hl7.fhir.r4.fhirpath.FHIRPathEngine;
 import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 
 public class FHIRPathEvaluator extends FHIRPathEngine {
 
   public FHIRPathEvaluator() throws IOException {
-    super(new SimpleWorkerContext());
+    super(SimpleWorkerContext.fromPackage(new FilesystemPackageCacheManager.Builder().build().loadPackage("hl7.fhir.r4.core#4.0.1", null))); 
   }
 
   @Override

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -10,9 +10,14 @@ import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 
 public class FHIRPathEvaluator extends FHIRPathEngine {
-
+  /**
+   * Initialize with FHIR R4 Core definitions.
+   */
   public FHIRPathEvaluator() throws IOException {
-    super(SimpleWorkerContext.fromPackage(new FilesystemPackageCacheManager.Builder().build().loadPackage("hl7.fhir.r4.core#4.0.1", null))); 
+    super(SimpleWorkerContext.fromPackage(
+          new FilesystemPackageCacheManager.Builder().build()
+              .loadPackage("hl7.fhir.r4.core#4.0.1", null)
+    )); 
   }
 
   @Override

--- a/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
+++ b/src/test/java/org/mitre/inferno/FHIRPathEvaluatorTest.java
@@ -45,21 +45,31 @@ class FHIRPathEvaluatorTest {
         "["
           + "{"
             + "\"type\":\"Patient.communication\","
-              + "\"element\":{"
-                + "\"language\":{"
-                  + "\"coding\":["
-                    + "{"
-                      + "\"system\":\"urn:ietf:bcp:47\","
-                      + "\"code\":\"en-US\","
-                      + "\"display\":\"English (United States)\""
-                    + "}"
-                  + "]"
-                + "},"
+            + "\"element\":{"
+              + "\"language\":{"
+                + "\"coding\":["
+                  + "{"
+                    + "\"system\":\"urn:ietf:bcp:47\","
+                    + "\"code\":\"en-US\","
+                    + "\"display\":\"English (United States)\""
+                  + "}"
+                + "]"
+              + "},"
               + "\"preferred\":true"
             + "}"
           + "}"
         + "]",
         pathEvaluator.evaluateToString(patient, "Patient.communication.where(preferred = true)")
+    );
+
+    Resource bundle = loadResource("bundle_fixture.json");
+    assertEquals(
+        "["
+          + "{"
+            + "\"type\":\"id\",\"element\":\"67890\""
+          + "}"
+        + "]",
+        pathEvaluator.evaluateToString(bundle, "Bundle.entry.resource.ofType(ServiceRequest).id")
     );
   }
 

--- a/src/test/resources/bundle_fixture.json
+++ b/src/test/resources/bundle_fixture.json
@@ -1,0 +1,60 @@
+{
+  "resourceType": "Bundle",
+  "id": "12345",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "12345",
+        "name": [
+          {
+            "resourceType": "HumanName",
+            "given": ["A"]
+          },
+          {
+            "resourceType": "HumanName",
+            "given": ["B"]
+          },
+          {
+            "resourceType": "HumanName",
+            "given": ["C"]
+          }
+        ],
+        "communication": [
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "en-US",
+                  "display": "English (United States)"
+                }
+              ]
+            },
+            "preferred": true
+          },
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "zh-CN",
+                  "display": "Chinese (China)"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+       "resource": {
+        "resourceType": "ServiceRequest",
+        "id": "67890",
+        "subject": {
+          "reference": "Patient/12345"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

Previously, evaluation of FHIR path expressions using the ofType function failed because no FHIR definitions were loaded. Now, the ofType function works because the base FHIR R4 definitions are loaded at startup.

# Testing Guidance

Start an instance of the fhirpath service and submit the following request:
- POST http://localhost:6789/evaluate?path=entry.resource.ofType(ServiceRequest)
- Body:
```
 {
      "resourceType": "Bundle",
      "entry": [
          {
              "resource": {
                  "resourceType": "ServiceRequest",
                  "id": "123"
              }
          },
          {
              "resource": {
                  "resourceType": "DeviceRequest",
                  "id": "456"
              }
          }
      ]
  }
```

confirm that only the ServiceRequest instance is return:
```
[
    {
        "type": "ServiceRequest",
        "element": {
            "resourceType": "ServiceRequest",
            "id": "123"
        }
    }
]
```